### PR TITLE
{PrivateDNS} Fix linter error

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/privatedns/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/commands.py
@@ -12,17 +12,17 @@ from azure.cli.command_modules.privatedns._format import (transform_privatedns_z
 def load_command_table(self, _):
 
     network_privatedns_zone_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.privatedns.operations.private_zones_operations#PrivateZonesOperations.{}',
+        operations_tmpl='azure.mgmt.privatedns.operations#PrivateZonesOperations.{}',
         client_factory=cf_privatedns_mgmt_zones
     )
 
     network_privatedns_virtual_network_link_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.privatedns.operations.virtual_network_links_operations#VirtualNetworkLinksOperations.{}',
+        operations_tmpl='azure.mgmt.privatedns.operations#VirtualNetworkLinksOperations.{}',
         client_factory=cf_privatedns_mgmt_virtual_network_links
     )
 
     network_privatedns_record_set_sdk = CliCommandType(
-        operations_tmpl='azure.mgmt.privatedns.operations.record_sets_operations#RecordSetsOperations.{}',
+        operations_tmpl='azure.mgmt.privatedns.operations#RecordSetsOperations.{}',
         client_factory=cf_privatedns_mgmt_record_sets
     )
 
@@ -38,7 +38,7 @@ def load_command_table(self, _):
         g.custom_command('import', 'import_zone')
         g.custom_command('export', 'export_zone')
         g.custom_command('create', 'create_privatedns_zone', client_factory=cf_privatedns_mgmt_zones, supports_no_wait=True)
-        g.generic_update_command('update', setter_name='begin_create_or_update', custom_func_name='update_privatedns_zone', supports_no_wait=True)
+        g.generic_update_command('update', setter_name='begin_update', custom_func_name='update_privatedns_zone', supports_no_wait=True)
         g.wait_command('wait')
 
     with self.command_group('network private-dns link vnet', network_privatedns_virtual_network_link_sdk) as g:
@@ -46,7 +46,7 @@ def load_command_table(self, _):
         g.show_command('show', 'get', table_transformer=transform_privatedns_link_table_output)
         g.command('list', 'list', table_transformer=transform_privatedns_link_table_output)
         g.custom_command('create', 'create_privatedns_link', client_factory=cf_privatedns_mgmt_virtual_network_links, supports_no_wait=True)
-        g.generic_update_command('update', setter_name='begin_create_or_update', custom_func_name='update_privatedns_link', setter_type=network_privatedns_custom, supports_no_wait=True)
+        g.generic_update_command('update', setter_name='update_privatedns_link', setter_type=network_privatedns_custom, supports_no_wait=True)
         g.wait_command('wait')
 
     with self.command_group('network private-dns record-set') as g:
@@ -56,12 +56,12 @@ def load_command_table(self, _):
     for record in supported_records:
         with self.command_group('network private-dns record-set {}'.format(record), network_privatedns_record_set_sdk) as g:
             g.show_command('show', 'get', transform=transform_privatedns_record_set_output, table_transformer=transform_privatedns_record_set_table_output)
-            g.command('delete', 'begin_delete', confirmation=True)
+            g.command('delete', 'delete', confirmation=True)
             g.custom_command('list', 'list_privatedns_record_set', client_factory=cf_privatedns_mgmt_record_sets, transform=transform_privatedns_record_set_output, table_transformer=transform_privatedns_record_set_table_output)
             g.custom_command('create', 'create_privatedns_record_set', client_factory=cf_privatedns_mgmt_record_sets, transform=transform_privatedns_record_set_output)
             g.custom_command('add-record', 'add_privatedns_{}_record'.format(record), client_factory=cf_privatedns_mgmt_record_sets, transform=transform_privatedns_record_set_output)
             g.custom_command('remove-record', 'remove_privatedns_{}_record'.format(record), client_factory=cf_privatedns_mgmt_record_sets, transform=transform_privatedns_record_set_output)
-            g.generic_update_command('update', setter_name='begin_create_or_update', custom_func_name='update_privatedns_record_set', transform=transform_privatedns_record_set_output)
+            g.generic_update_command('update', setter_name='update', custom_func_name='update_privatedns_record_set', transform=transform_privatedns_record_set_output)
 
     with self.command_group('network private-dns record-set soa', network_privatedns_record_set_sdk) as g:
         g.show_command('show', 'get', transform=transform_privatedns_record_set_output, table_transformer=transform_privatedns_record_set_table_output)
@@ -69,9 +69,9 @@ def load_command_table(self, _):
 
     with self.command_group('network private-dns record-set cname', network_privatedns_record_set_sdk) as g:
         g.show_command('show', 'get', transform=transform_privatedns_record_set_output, table_transformer=transform_privatedns_record_set_table_output)
-        g.command('delete', 'begin_delete', confirmation=True)
+        g.command('delete', 'delete', confirmation=True)
         g.custom_command('list', 'list_privatedns_record_set', client_factory=cf_privatedns_mgmt_record_sets, transform=transform_privatedns_record_set_output, table_transformer=transform_privatedns_record_set_table_output)
         g.custom_command('create', 'create_privatedns_record_set', client_factory=cf_privatedns_mgmt_record_sets, transform=transform_privatedns_record_set_output)
         g.custom_command('set-record', 'add_privatedns_cname_record', client_factory=cf_privatedns_mgmt_record_sets, transform=transform_privatedns_record_set_output)
         g.custom_command('remove-record', 'remove_privatedns_cname_record', client_factory=cf_privatedns_mgmt_record_sets, transform=transform_privatedns_record_set_output)
-        g.generic_update_command('update', setter_name='begin_create_or_update', custom_func_name='update_privatedns_record_set', transform=transform_privatedns_record_set_output)
+        g.generic_update_command('update', setter_name='update', custom_func_name='update_privatedns_record_set', transform=transform_privatedns_record_set_output)

--- a/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/privatedns/custom.py
@@ -124,7 +124,7 @@ def import_zone(cmd, resource_group_name, private_zone_name, file_name):
             rs.soa_record.host = root_soa.soa_record.host
             rs_name = '@'
         try:
-            client.record_sets.begin_create_or_update(
+            client.record_sets.create_or_update(
                 resource_group_name, private_zone_name, rs_type, rs_name, rs)
             cum_records += record_count
             print("({}/{}) Imported {} records of type '{}' and name '{}'"
@@ -307,7 +307,7 @@ def update_privatedns_link(cmd, resource_group_name, private_zone_name, virtual_
 
     aux_subscription = parse_resource_id(link.virtual_network.id)['subscription']
     client = get_mgmt_service_client(cmd.cli_ctx, PrivateDnsManagementClient, aux_subscriptions=[aux_subscription]).virtual_network_links
-    return client.update(resource_group_name, private_zone_name, virtual_network_link_name, link, if_match=if_match)
+    return client.begin_update(resource_group_name, private_zone_name, virtual_network_link_name, link, if_match=if_match)
 
 
 def create_privatedns_record_set(cmd, resource_group_name, private_zone_name, relative_record_set_name, record_type, metadata=None, ttl=3600):
@@ -315,7 +315,7 @@ def create_privatedns_record_set(cmd, resource_group_name, private_zone_name, re
     from azure.mgmt.privatedns.models import RecordSet
     client = get_mgmt_service_client(cmd.cli_ctx, PrivateDnsManagementClient).record_sets
     record_set = RecordSet(ttl=ttl, metadata=metadata)
-    return client.begin_create_or_update(resource_group_name, private_zone_name, record_type, relative_record_set_name, record_set, if_none_match='*')
+    return client.create_or_update(resource_group_name, private_zone_name, record_type, relative_record_set_name, record_set, if_none_match='*')
 
 
 def list_privatedns_record_set(cmd, resource_group_name, private_zone_name, record_type=None):
@@ -363,7 +363,7 @@ def _privatedns_add_save_record(client, record, record_type, relative_record_set
         record_set = RecordSet(ttl=3600)
 
     _privatedns_add_record(record_set, record, record_type, is_list)
-    return client.begin_create_or_update(resource_group_name, private_zone_name, record_type, relative_record_set_name, record_set)
+    return client.create_or_update(resource_group_name, private_zone_name, record_type, relative_record_set_name, record_set)
 
 
 def add_privatedns_aaaa_record(cmd, resource_group_name, private_zone_name, relative_record_set_name, ipv6_address):
@@ -557,9 +557,9 @@ def _privatedns_remove_record(client, record, record_type, relative_record_set_n
 
     if not records_remaining and not keep_empty_record_set:
         logger.info('Removing empty %s record set: %s', record_type, relative_record_set_name)
-        return client.begin_delete(resource_group_name, private_zone_name, record_type, relative_record_set_name)
+        return client.delete(resource_group_name, private_zone_name, record_type, relative_record_set_name)
 
-    return client.begin_create_or_update(resource_group_name, private_zone_name, record_type, relative_record_set_name, record_set)
+    return client.create_or_update(resource_group_name, private_zone_name, record_type, relative_record_set_name, record_set)
 
 
 def dict_matches_filter(d, filter_dict):


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Changes I made:
- Remove wrong `begin_` prefix from `record-set` command, only long running operation need this prefix, `create_or_update` and `delete` are not LRO for `record-set`, you can check if we need add `begin_` prefix in SDK source code.
- Remove unnecessary subitem for `operations_tmpl='azure.mgmt.privatedns.operations#PrivateZonesOperations.{}'`
- Revert from `begin_create_or_update` to `begin_update` from some `update` commands as previously we use `update`.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
